### PR TITLE
added support for CoreOS

### DIFF
--- a/manifests/images.pp
+++ b/manifests/images.pp
@@ -47,6 +47,14 @@ define pxe::images (
         baseurl => $baseurl,
       }
     }
+    coreos: {
+      pxe::images::coreos { "${os} ${ver} ${arch}":
+        arch    => $arch,
+        ver     => $ver,
+        os      => $os,
+        baseurl => $baseurl,
+      }
+    }
     redhat: {
       if $baseurl != '' {
         pxe::images::redhat { "${os} ${ver} ${arch}":

--- a/manifests/images/coreos.pp
+++ b/manifests/images/coreos.pp
@@ -1,0 +1,35 @@
+# Class: pxe::images::debian
+#
+# Retrieve the requested CoreOS image
+#
+define pxe::images::coreos(
+  $arch,
+  $ver,
+  $os      = 'coreos',
+  $baseurl = ''
+) {
+  
+  if $arch != 'amd64' { err("Only arch = 'amd64' is supported for CoreOS, ${arch} is invalid") }
+  if $os != 'coreos' { err("Only os = 'coreos' is supported for CoreOS, ${os} is invalid") }
+
+  if $baseurl == '' {
+    $srclocation = "http://stable.release.core-os.net/${arch}-usr/${ver}"
+  } else {
+    $srclocation = "${baseurl}/${arch}-usr/${ver}"
+  }
+
+  $tftp_root = $::pxe::tftp_root
+
+  exec {
+    "wget ${os} pxe linux ${arch} ${ver}":
+      path    => ['/usr/bin', '/usr/local/bin'],
+      cwd     => "${tftp_root}/images/${os}/${ver}/${arch}",
+      command => "wget ${srclocation}/coreos_production_pxe.vmlinuz",
+      creates => "${tftp_root}/images/${os}/${ver}/${arch}/coreos_production_pxe.vmlinuz";
+    "wget ${os} pxe initrd.img ${arch} ${ver}":
+      path    => ['/usr/bin', '/usr/local/bin'],
+      cwd     => "${tftp_root}/images/${os}/${ver}/${arch}",
+      command => "wget ${srclocation}/coreos_production_pxe_image.cpio.gz",
+      creates => "${tftp_root}/images/${os}/${ver}/${arch}/coreos_production_pxe_image.cpio.gz";
+  }
+}


### PR DESCRIPTION
Support for CoreOS added by taking example from debian. Basic testing has been done on my side, but I'm no expert on PXE or on CoreOS (yet). I can confirm that downloading of binaries from CoreOS website works.