### PR TITLE
Remove references to concat::setup

### DIFF
--- a/manifests/menu.pp
+++ b/manifests/menu.pp
@@ -14,8 +14,6 @@ define pxe::menu (
   $root     = 'default',
 ) {
 
-  include concat::setup
-
   $tftp_root = $::pxe::tftp_root
   $fullpath  = "${tftp_root}/pxelinux.cfg"
 

--- a/manifests/menu/installentry.pp
+++ b/manifests/menu/installentry.pp
@@ -24,8 +24,6 @@ define pxe::menu::installentry (
     $menutitle = ''
 ) {
 
-  include concat::setup
-
   if $menutitle == '' {
     $label = $title
   } else {


### PR DESCRIPTION
Remove references to `concat::setup`, which has been removed in puppetlabs/concat 2.x.x. This fixes this error, which I was getting since upgrading to puppetabs.concat 2.1.0:

```
[jg4461@pxe ~]$ sudo puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Could not find class concat::setup for pxe.resnet.bris.ac.uk on node pxe.resnet.bris.ac.uk
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

You don't actually need to `include` any part of the concat module at all - just reference it directly with one instance of `concat { '/path/to/file': }` and as many calls to `concat::fragment` as you like.