### PR TITLE
add mfsbsd variants, ver > 10, docs and validation

### DIFF
--- a/manifests/images.pp
+++ b/manifests/images.pp
@@ -67,7 +67,7 @@ define pxe::images (
         }
       }
     }
-    mfsbsd: {
+    /^mfsbsd(-se|-mini)$/: {
       pxe::images::mfsbsd { "${os} ${ver} ${arch}":
         arch    => $arch,
         ver     => $ver,

--- a/manifests/images/mfsbsd.pp
+++ b/manifests/images/mfsbsd.pp
@@ -1,28 +1,61 @@
-# Class: pxe::images::mfsbsd
+# == Resource: pxe::images::mfsbsd
 #
-# Retrieve the requested MfsBSD image
+# Provisioning the resource will retrieve the requested MfsBSD images.
+#
+# === Parameters
+# [*arch*]
+#   The architecture. Can be i386 and amd64 for FreeBSD < 11.0-RELEASE. Can
+#   be amd64 only for FreeBSD >= 11.0-RELEASE.
+#
+# [*baseurl*]
+#   The http endpoint to download the images from. Lends itself to proxies
+#   like aptcacher-ng.
+#
+# [*os*]
+#   The variant of mfsbsd to download. Can be any of {'mfsbsd', 'mfsbsd-se',
+#   'mfsbsd-mini'}
+#
+# [*ver*]
+#   The version of mfsbsd to download. Is constructed in the fashion of
+#   $MAJOR.$MINOR-RELEASE as in 8.4-RELEASE.
 #
 define pxe::images::mfsbsd(
   $arch,
   $ver,
-  $os      = 'mfsbsd',
-  $baseurl = ''
+  $baseurl = undef,
+  $os = 'mfsbsd',
 ) {
 
-  if $baseurl == '' {
-    case $os {
-      default:  { $srclocation = 'http://mfsbsd.vx.sk/files/images' }
-    }
+  # TODO: with deprecation of puppet < 4, use puppet regex type and fail()
+  validate_re($arch, '^(amd64|i386)$')
+  validate_re($os, '^(mfsbsd|mfsbsd-se|mfsbsd-mini)$')
+  validate_re($ver, '^\d+.\d-RELEASE$')
+
+  $ver_a = split($ver,'[.-]')
+  $maj = $ver_a[0]
+  $min = $ver_a[1]
+
+  $srclocation = $baseurl ? {
+    /(http|ftp):\/\/.+/ => $baseurl,
+    default             => 'http://mfsbsd.vx.sk/files/images',
   }
 
+  # NOTICE: with 11.0-RELEASE, mm@ has dropped i386 and changed the path
   # http://mfsbsd.vx.sk/files/images/10/amd64/mfsbsd-10.2-RELEASE-amd64.img
-  $path    = "${os}-${ver}-${arch}.img"
+  # http://mfsbsd.vx.sk/files/images/11/mfsbsd-11.0-RELEASE-amd64.img
+
+  # TODO: with puppet > 4, parse numbers from strings, use numeric comparison
+  $path = $maj ? {
+    /11/    => "${maj}/${os}-${ver}-${arch}.img",
+    default => "${maj}/${arch}/${os}-${ver}-${arch}.img",
+  }
+
   $tftp_root = $::pxe::tftp_root
 
   exec { "wget ${os} live image ${arch} ${ver}":
-      path    => ['/usr/bin', '/usr/local/bin'],
-      cwd     => "${tftp_root}/images/${os}/",
-      command => "wget ${srclocation}/${path}",
-      creates => "${tftp_root}/images/${os}/${path}";
+    path    => ['/usr/bin', '/usr/local/bin'],
+    cwd     => "${tftp_root}/images/${os}/${ver}/${arch}",
+    command => "wget ${srclocation}/${path}",
+    creates => "${tftp_root}/images/${os}/${path}";
   }
 }


### PR DESCRIPTION
Hi,

While working with newer mfsbsd images, I thought the mfsbsd-resource could use some love:

mfsbsd has for some versions variants mfsbsd, mfsbsd-se and
mfsbsd-mini. Add Possible os-versions for the image-provider.

mm@ has changed the path for mfsbsd > 10, Adapt path var accordingly.

Add some doc stubs for better understanding and add some basic
validation to check parameters passed.

	modified:   manifests/images.pp
	modified:   manifests/images/mfsbsd.pp

I noticed you had the FreeBSD and Friends test commented out, so I did not bother much about testing. While developing, I did lots of provisioning with test-kitchen and the puppet plugin, but did not go further. Thanks for your work on this and the other puppet modules. Cheers