### PR TITLE
Fix JSON gem dependencies for Ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ group :test do
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
+  gem 'json', '~>1.0' if RUBY_VERSION == '1.9.3'
+  gem 'json_pure', '~>1.0' if RUBY_VERSION == '1.9.3'
 end
 
 group :development do

--- a/manifests/images/coreos.pp
+++ b/manifests/images/coreos.pp
@@ -8,7 +8,7 @@ define pxe::images::coreos(
   $os      = 'coreos',
   $baseurl = ''
 ) {
-  
+
   if $arch != 'amd64' { err("Only arch = 'amd64' is supported for CoreOS, ${arch} is invalid") }
   if $os != 'coreos' { err("Only os = 'coreos' is supported for CoreOS, ${os} is invalid") }
 

--- a/manifests/syslinux.pp
+++ b/manifests/syslinux.pp
@@ -31,33 +31,48 @@ class pxe::syslinux {
     ensure => directory,
   }
 
-  file {
-    "${tftp_root}/pxelinux.0":
-      source    => "${syslinux_dir}/bios/core/pxelinux.0",
-      require   => Exec['syslinux_install'];
-    "${tftp_root}/syslinux/menu.c32":
-      source    => "${syslinux_dir}/bios/com32/menu/menu.c32",
-      require   => Exec['syslinux_install'];
-    "${tftp_root}/syslinux/vesamenu.c32":
-      source    => "${syslinux_dir}/bios/com32/menu/vesamenu.c32",
-      require   => Exec['syslinux_install'];
-    "${tftp_root}/syslinux/reboot.c32":
-      source    => "${syslinux_dir}/bios/com32/modules/reboot.c32",
-      require   => Exec['syslinux_install'];
-    "${tftp_root}/syslinux/ldlinux.c32":
-      source    => "${syslinux_dir}/bios/com32/elflink/ldlinux/ldlinux.c32",
-      require   => Exec['syslinux_install'];
-    "${tftp_root}/syslinux/libcom32.c32":
-      source    => "${syslinux_dir}/bios/com32/lib/libcom32.c32",
-      require   => Exec['syslinux_install'];
-    "${tftp_root}/syslinux/libutil.c32":
-      source    => "${syslinux_dir}/bios/com32/libutil/libutil.c32",
-      require   => Exec['syslinux_install'];
-    "${tftp_root}/syslinux/memdisk":
-      source    => "${syslinux_dir}/bios/memdisk/memdisk",
-      require   => Exec['syslinux_install'];
-    "${tftp_root}/pxelinux.cfg":
-      ensure    => directory;
+  file { "${tftp_root}/pxelinux.0":
+    source  => "${syslinux_dir}/bios/core/pxelinux.0",
+    require => Exec['syslinux_install'],
+  }
+
+  file { "${tftp_root}/syslinux/menu.c32":
+    source  => "${syslinux_dir}/bios/com32/menu/menu.c32",
+    require => Exec['syslinux_install'],
+  }
+
+  file { "${tftp_root}/syslinux/vesamenu.c32":
+    source  => "${syslinux_dir}/bios/com32/menu/vesamenu.c32",
+    require => Exec['syslinux_install'],
+  }
+
+  file { "${tftp_root}/syslinux/reboot.c32":
+    source  => "${syslinux_dir}/bios/com32/modules/reboot.c32",
+    require => Exec['syslinux_install'],
+  }
+
+  file { "${tftp_root}/syslinux/ldlinux.c32":
+    source  => "${syslinux_dir}/bios/com32/elflink/ldlinux/ldlinux.c32",
+    require => Exec['syslinux_install'],
+  }
+
+  file { "${tftp_root}/syslinux/libcom32.c32":
+    source  => "${syslinux_dir}/bios/com32/lib/libcom32.c32",
+    require => Exec['syslinux_install'],
+  }
+
+  file { "${tftp_root}/syslinux/libutil.c32":
+    source  => "${syslinux_dir}/bios/com32/libutil/libutil.c32",
+    require => Exec['syslinux_install'],
+  }
+
+  file { "${tftp_root}/syslinux/memdisk":
+    source  => "${syslinux_dir}/bios/memdisk/memdisk",
+    require => Exec['syslinux_install'],
+  }
+
+  file { "${tftp_root}/pxelinux.cfg":
+    ensure => directory,
   }
 
 }


### PR DESCRIPTION
Without this change, the tests fail due to lack of gem pinning.  Here we
pin the json gems to the correct version based on ruby version.