### PR TITLE
correct bug when validating mfsbsd images

### DIFF
--- a/manifests/images.pp
+++ b/manifests/images.pp
@@ -67,7 +67,7 @@ define pxe::images (
         }
       }
     }
-    /^mfsbsd(-se|-mini)$/: {
+    /^mfsbsd(-se|-mini)?$/: {
       pxe::images::mfsbsd { "${os} ${ver} ${arch}":
         arch    => $arch,
         ver     => $ver,

--- a/manifests/images/mfsbsd.pp
+++ b/manifests/images/mfsbsd.pp
@@ -51,11 +51,13 @@ define pxe::images::mfsbsd(
   }
 
   $tftp_root = $::pxe::tftp_root
+  $imgdir    = "${tftp_root}/images/${os}/${ver}/${arch}"
+  $imgfile   = "${os}-${ver}-${arch}.img"
 
   exec { "wget ${os} live image ${arch} ${ver}":
     path    => ['/usr/bin', '/usr/local/bin'],
-    cwd     => "${tftp_root}/images/${os}/${ver}/${arch}",
+    cwd     => $imgdir,
     command => "wget ${srclocation}/${path}",
-    creates => "${tftp_root}/images/${os}/${path}";
+    creates => "${imgdir}/${imgfile}",
   }
 }

--- a/manifests/images/mfsbsd.pp
+++ b/manifests/images/mfsbsd.pp
@@ -35,29 +35,29 @@ define pxe::images::mfsbsd(
   $maj = $ver_a[0]
   $min = $ver_a[1]
 
-  $srclocation = $baseurl ? {
+  $remotebase = $baseurl ? {
     /(http|ftp):\/\/.+/ => $baseurl,
     default             => 'http://mfsbsd.vx.sk/files/images',
   }
 
+  $tftp_root = $::pxe::tftp_root
+  $localdir    = "${tftp_root}/images/${os}/${ver}/${arch}"
+
   # NOTICE: with 11.0-RELEASE, mm@ has dropped i386 and changed the path
   # http://mfsbsd.vx.sk/files/images/10/amd64/mfsbsd-10.2-RELEASE-amd64.img
   # http://mfsbsd.vx.sk/files/images/11/mfsbsd-11.0-RELEASE-amd64.img
-
   # TODO: with puppet > 4, parse numbers from strings, use numeric comparison
-  $path = $maj ? {
-    /11/    => "${maj}/${os}-${ver}-${arch}.img",
-    default => "${maj}/${arch}/${os}-${ver}-${arch}.img",
+  $remotedir = $maj ? {
+    /11/    => $maj,
+    default => "${maj}/${arch}/",
   }
 
-  $tftp_root = $::pxe::tftp_root
-  $imgdir    = "${tftp_root}/images/${os}/${ver}/${arch}"
   $imgfile   = "${os}-${ver}-${arch}.img"
 
   exec { "wget ${os} live image ${arch} ${ver}":
+    cwd     => $localdir,
+    command => "wget ${remotebase}/${remotedir}/${imgfile}",
+    creates => "${localdir}/${imgfile}",
     path    => ['/usr/bin', '/usr/local/bin'],
-    cwd     => $imgdir,
-    command => "wget ${srclocation}/${path}",
-    creates => "${imgdir}/${imgfile}",
   }
 }


### PR DESCRIPTION
Hi,

I am so sorry, I fat-fingered a bug into your module. When switching my envs, I noticed a rather important char missing, which I fixed.

The regex /^mfsbsd(-se|-mini)$/ will not match on "pure" mfsbsd
images (those without -se and without -mini), which is not the intent
here.  /^mfsbsd(-se|-mini)?$/ will match correctly on the three options
applicable.

	modified:   manifests/images.pp

I am so sorry to have messed this up ... Thanks again for your work